### PR TITLE
s/FALZORIZE/show-factors/g

### DIFF
--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--falzorize",
+        "--show-factors",
         type=int,
         help="Show P Q, the factors of N",
         default=None,


### PR DESCRIPTION
Since FALZORIZE is not a word in the english dicctionary and we are always factoring, "--show-factors" is a more succinct name.