### PR TITLE
wrap cryptodome imports with try/excepts for cryptodomex compat

### DIFF
--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -16,7 +16,7 @@ import argparse
 import urllib3
 import tempfile
 from glob import glob
-from Crypto.PublicKey import RSA
+from lib.crypto_wrapper import RSA
 from lib.rsa_attack import RSAAttack
 from lib.rsalibnum import invmod
 from lib.utils import get_numeric_value, print_results, get_base64_value, n2s

--- a/attacks/multi_keys/common_modulus.py
+++ b/attacks/multi_keys/common_modulus.py
@@ -3,7 +3,7 @@
 
 from attacks.abstract_attack import AbstractAttack
 from lib.rsalibnum import gcd, common_modulus
-from Crypto.Util.number import long_to_bytes, bytes_to_long
+from lib.crypto_wrapper import long_to_bytes, bytes_to_long
 import itertools
 
 

--- a/attacks/multi_keys/same_n_huge_e.py
+++ b/attacks/multi_keys/same_n_huge_e.py
@@ -3,7 +3,7 @@
 
 from attacks.abstract_attack import AbstractAttack
 import gmpy2
-from Crypto.Util import number
+from lib.crypto_wrapper import number
 from lib.utils import timeout, TimeoutError
 from lib.rsalibnum import gcdext, powmod
 

--- a/attacks/single_key/boneh_durfee.py
+++ b/attacks/single_key/boneh_durfee.py
@@ -3,7 +3,7 @@
 
 from attacks.abstract_attack import AbstractAttack
 import subprocess
-from Crypto.PublicKey import RSA
+from lib.crypto_wrapper import RSA
 from lib.keys_wrapper import PrivateKey
 from lib.utils import rootpath
 

--- a/attacks/single_key/factordb.py
+++ b/attacks/single_key/factordb.py
@@ -7,7 +7,7 @@ import requests
 from lib.rsalibnum import invmod
 from lib.keys_wrapper import PrivateKey
 from lib.exceptions import FactorizationError
-from Crypto.Util.number import long_to_bytes
+from lib.crypto_wrapper import long_to_bytes
 from lib.utils import timeout, TimeoutError
 from gmpy2 import powmod
 

--- a/attacks/single_key/small_crt_exp.py
+++ b/attacks/single_key/small_crt_exp.py
@@ -3,7 +3,7 @@
 
 from attacks.abstract_attack import AbstractAttack
 import subprocess
-from Crypto.PublicKey import RSA
+from lib.crypto_wrapper import RSA
 from lib.keys_wrapper import PrivateKey
 from lib.utils import rootpath
 

--- a/lib/crypto_wrapper.py
+++ b/lib/crypto_wrapper.py
@@ -1,0 +1,22 @@
+try:
+    from Crypto.Cipher import PKCS1_OAEP
+except ModuleNotFoundError:
+    from Cryptodome.Cipher import PKCS1_OAEP
+try:
+    from Crypto.PublicKey import RSA
+except ModuleNotFoundError:
+    from Cryptodome.PublicKey import RSA
+try:
+    from Crypto.Util import number
+except ModuleNotFoundError:
+    from Cryptodome.Util import number
+try:
+    from Crypto.Util.number import long_to_bytes, bytes_to_long
+except ModuleNotFoundError:
+    from Cryptodome.Util.number import long_to_bytes, bytes_to_long
+
+bytes_to_long = bytes_to_long
+long_to_bytes = long_to_bytes
+number = number
+PKCS1_OAEP = PKCS1_OAEP
+RSA = RSA

--- a/lib/crypto_wrapper.py
+++ b/lib/crypto_wrapper.py
@@ -15,9 +15,9 @@ try:
 except ModuleNotFoundError:
     from Cryptodome.Util.number import long_to_bytes, bytes_to_long
 
-__all__= [RSA, PKCS1_OAEP, number, long_to_bytes, bytes_to_long]
 bytes_to_long = bytes_to_long
 long_to_bytes = long_to_bytes
 number = number
 PKCS1_OAEP = PKCS1_OAEP
 RSA = RSA
+__all__= [RSA, PKCS1_OAEP, number, long_to_bytes, bytes_to_long]

--- a/lib/crypto_wrapper.py
+++ b/lib/crypto_wrapper.py
@@ -15,6 +15,7 @@ try:
 except ModuleNotFoundError:
     from Cryptodome.Util.number import long_to_bytes, bytes_to_long
 
+__all__= [RSA, PKCS1_OAEP, number, long_to_bytes, bytes_to_long]
 bytes_to_long = bytes_to_long
 long_to_bytes = long_to_bytes
 number = number

--- a/lib/keys_wrapper.py
+++ b/lib/keys_wrapper.py
@@ -5,8 +5,8 @@ import logging
 import tempfile
 import binascii
 import subprocess
-from Crypto.PublicKey import RSA
-from Crypto.Cipher import PKCS1_OAEP
+from lib.crypto_wrapper import RSA
+from lib.crypto_wrapper import PKCS1_OAEP
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
 from lib.conspicuous_check import privatekey_check

--- a/lib/rsa_attack.py
+++ b/lib/rsa_attack.py
@@ -7,7 +7,7 @@ from lib.keys_wrapper import PublicKey, PrivateKey
 from lib.exceptions import FactorizationError
 from lib.utils import print_results
 from lib.fdb import send2fdb
-from Crypto.Util.number import bytes_to_long, long_to_bytes
+from lib.crypto_wrapper import bytes_to_long, long_to_bytes
 import inspect
 from lib.rsalibnum import is_prime, isqrt, gcd
 import traceback

--- a/lib/rsalibnum.py
+++ b/lib/rsalibnum.py
@@ -6,7 +6,7 @@ import binascii
 import math
 import logging
 import random
-from Crypto.Util.number import bytes_to_long
+from lib.crypto_wrapper import bytes_to_long
 
 logger = logging.getLogger("global_logger")
 


### PR DESCRIPTION
This allows RsaCtfTool to run on vanilla Kali Linux without changing how it runs on any other operating systems