### PR TITLE
Fix euler's totient in factordb 

### DIFF
--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -405,7 +405,6 @@ if __name__ == "__main__":
             selected_attacks = attacks_list
 
         tmpfile = tempfile.NamedTemporaryFile()
-        #print(tmpfile)
         with open(tmpfile.name, "wb") as tmpfd:
             tmpfd.write(RSA.construct((35, 3)).publickey().exportKey())
             attackobj.attack_single_key(tmpfile.name, selected_attacks, test=True)

--- a/lib/keys_wrapper.py
+++ b/lib/keys_wrapper.py
@@ -70,6 +70,7 @@ class PrivateKey(object):
         e=None,
         n=None,
         d=None,
+        phi=None,
         filename=None,
         password=None,
     ):
@@ -96,6 +97,8 @@ class PrivateKey(object):
             self.n = n
 
         self.phi = None
+        if phi is not None:
+            self.phi = phi
 
         if self.p is not None and self.q is not None and self.phi is None:
             if self.p != self.q:

--- a/lib/rsa_attack.py
+++ b/lib/rsa_attack.py
@@ -255,8 +255,8 @@ class RSAAttack(object):
     def attack_single_key(self, publickey, attacks_list=[], test=False):
         """Run attacks on single keys"""
 
-        c = 0 # Attack counter
-        l =  len(attacks_list) 
+        c = 0  # Attack counter
+        l = len(attacks_list) 
         if l == 0:
             self.args.attack = "all"
 
@@ -265,7 +265,7 @@ class RSAAttack(object):
             for attack in self.implemented_attacks:
                 c += 1
                 if attack.can_run():
-                    self.logger.info("[*] %d of %d, Testing: %s" % (c,l,attack.get_name()))
+                    self.logger.info("[*] %d of %d, Testing: %s" % (c, l, attack.get_name()))
                     try:
                         try:
                             if attack.test():


### PR DESCRIPTION
Fixed #338 

- All linting warnings (except those in XYXZ) are lifted

- I feel like it makes more sense to set private key `phi` than directly decrypt ciphertext in the function, but please let me know if that introduces bugs for other attacks. Will change it back.   

- I am not sure what `solveforp` is doing here. Left it as it is for now, but happy to make the function cleaner if someone knows what edge cases the function deals with. 

Sample Output
```
└─$ time ./RsaCtfTool.py -n 257827703087398016057355158654193468564980243813004452658087616586210487667215030370871398983230710387803731676134007721137156696714627083072326445637415561591372586919746606752675050732692230618293581354674196658443898625965651230501721590806987488038754683843111434873697465691139129703835890867256688046172118591 -e 65537 --uncipher 194667317703687479298989188290833629421904543231503224641743768867721632949682167895699280370759100055314992068135383846690184090232092994595979623784341194946153538127175310278245722299688212621004144260665233469561373125699948009903943019071999887294005117156960295183926108287198987970959145603429337056005819069 --attack factordb
private argument is not set, the private key will not be displayed, even if recovered.

[*] Testing key /tmp/tmp4mdky8uy.
[*] Performing factordb attack on /tmp/tmp4mdky8uy.
[*] Attack success with factordb method !

Results for /tmp/tmp4mdky8uy:

Unciphered data :
HEX : 0x696374667b736d346c6c5f7072316d65735f6172655f6e305f6e305f39623132393434337d0a
INT (big endian) : 13417509722382695540362968023909576616640795468890045561607192167142506709009625171732167946
INT (little endian) : 1335412362026446523630569196961759828517612905583806931284709521828848496203920243271426921
utf-8 : ictf{sm4ll_pr1mes_are_n0_n0_9b129443}

utf-16 : 捩晴獻㑭汬灟ㅲ敭彳牡彥の湟弰戹㈱㐹㌴੽
STR : b'ictf{sm4ll_pr1mes_are_n0_n0_9b129443}\n'

real    0m1.334s
user    0m0.316s
sys     0m0.023s
```