### PR TITLE
Fix crash for --public '*.pub' without --uncipherfile

### DIFF
--- a/attacks/multi_keys/common_modulus.py
+++ b/attacks/multi_keys/common_modulus.py
@@ -26,7 +26,7 @@ class Attack(AbstractAttack):
         """Common modulus attack"""
         if len(publickeys) < 2:
             return (None, None)
-        if len(cipher) < 2:
+        if cipher is None or len(cipher) < 2:
             return (None, None)
 
         plains = []


### PR DESCRIPTION
When attempting to exploit a common factor in multiple keys with `RsaCtfTool.py --public '*.pub'`, RsaCtfTool crashes with

```
[*] Multikey mode using keys: jiAvqtWm81.pub, pnB2no_G4g.pub, pgcYDb2ltL.pub, _w4AkKhONU.pub, ...
[*] Performing common_modulus attack.
Traceback (most recent call last):
  File "/home/cabbache/Desktop/ctftools/RsaCtfTool/RsaCtfTool.py", line 414, in <module>
    found = attackobj.attack_multiple_keys(args.publickey, attacks_list)
  File "/home/cabbache/Desktop/ctftools/RsaCtfTool/lib/rsa_attack.py", line 233, in attack_multiple_keys
    self.priv_key, unciphered = attack_module.attack(
  File "/home/cabbache/Desktop/ctftools/RsaCtfTool/attacks/multi_keys/common_modulus.py", line 29, in attack
    if len(cipher) < 2:
TypeError: object of type 'NoneType' has no len()
```

This is because before the common factor attack it is trying to do the common modulus attack and I had not provided a --uncipherfile (which is required for common modulus).

I patched this by making it skip the common modulus attack if --uncipherfile is not provided.