### PR TITLE
update requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cryptography==3.3.2
 urllib3==1.26.5
 requests==2.25.1
 gmpy==1.17
-gmpy2==2.1.0b5
+gmpy2==2.1.2
 pycryptodome==3.10.4
 tqdm
 z3-solver


### PR DESCRIPTION
The current version of gmpy2 fails to build with python >= 3.10 , seems the check was added later on in 2.1.0b6 (https://github.com/aleaxit/gmpy/commit/1cbb59affb86389d5ba7842304f9ce06028ed879)

```
#52 8.784       In file included from src/gmpy2.c:461:
#52 8.784       src/gmpy2.h:446: warning: "Py_RETURN_NOTIMPLEMENTED" redefined
#52 8.784         446 | #define Py_RETURN_NOTIMPLEMENTED \
#52 8.784             |
#52 8.784       In file included from /usr/include/python3.10/Python.h:74,
#52 8.784                        from src/gmpy2.c:445:
#52 8.784       /usr/include/python3.10/object.h:623: note: this is the location of the previous definition
#52 8.784         623 | #define Py_RETURN_NOTIMPLEMENTED return Py_NewRef(Py_NotImplemented)
#52 8.784             |
#52 8.784       In file included from src/gmpy2.c:593:
#52 8.784       src/gmpy2_hash.c: In function ‘_mpfr_hash’:
#52 8.784       src/gmpy2_hash.c:150:20: error: ‘_PyHASH_NAN’ undeclared (first use in this function); did you mean ‘Py_IS_NAN’?
#52 8.784         150 |             return _PyHASH_NAN;
#52 8.784             |                    ^~~~~~~~~~~
#52 8.784             |                    Py_IS_NAN
#52 8.784       src/gmpy2_hash.c:150:20: note: each undeclared identifier is reported only once for each function it appears in
#52 8.784       error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
#52 8.784       [end of output]
#52 8.784
#52 8.784   note: This error originates from a subprocess, and is likely not a problem with pip.
#52 8.786 error: legacy-install-failure
#52 8.786
#52 8.786 × Encountered error while trying to install package.
#52 8.786 ╰─> gmpy2
```