### PR TITLE
Fix Runnaway SageMath Process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ target/
 
 # Sage stuff
 *.sage.py
+
+# python virtual environment
+.venv

--- a/attacks/single_key/ecm2.py
+++ b/attacks/single_key/ecm2.py
@@ -3,7 +3,8 @@
 
 from attacks.abstract_attack import AbstractAttack
 import subprocess
-from lib.utils import rootpath
+import os
+from lib.utils import rootpath, TimeoutError, terminate_proc_tree
 from lib.number_theory import invert, powmod
 
 
@@ -21,13 +22,13 @@ class Attack(AbstractAttack):
         try:
             sageresult = []
             try:
-                sageresult = subprocess.check_output(
-                    ["sage", "%s/sage/ecm2.sage" % rootpath, str(publickey.n)],
-                    timeout=self.timeout,
-                    stderr=subprocess.DEVNULL,
-                )
+                sage_proc = subprocess.Popen(["sage", "%s/sage/ecm2.sage" % rootpath, str(publickey.n)], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                sage_proc.wait(timeout=self.timeout)
+                stdout, stderr = sage_proc.communicate()
+                sageresult = stdout
                 sageresult = sageresult[1:-2].split(b", ")
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, TimeoutError):
+                terminate_proc_tree(os.getpgid(sage_proc.pid))
                 return (None, None)
 
             if len(sageresult) > 0:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -9,6 +9,7 @@ import logging
 import subprocess
 import contextlib
 import binascii
+import psutil
 from lib.keys_wrapper import PublicKey
 from lib.number_theory import invmod
 
@@ -239,3 +240,11 @@ def binary_search(L, n):
         else:
             left = mid + 1
     return -1
+
+def terminate_proc_tree(pid, including_parent=False):    
+    parent = psutil.Process(pid)
+    children = parent.children(recursive=True)
+    for child in children:
+        child.kill()
+    if including_parent:
+        parent.kill()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pycryptodome==3.10.4
 tqdm
 z3-solver
 bitarray
+psutil==5.9.4


### PR DESCRIPTION
This PR fixes an issue when `ecm.py` and `ecm2.py` spawns a parallel `sage` process and subsequently spawns child processes that are not terminated with the typical `subprocess.check_output()` per this blog post:
- [Kill a Python subprocess and its children when a timeout is reached](https://alexandra-zaharia.github.io/posts/kill-subprocess-and-its-children-on-timeout-python/)

Then adapted what I understand should be a reasonable cross-platform method of terminating child processes
- [subprocess: deleting child processes in Windows](https://stackoverflow.com/a/4229404/12648588)

## Feature
- [x] defined `terminate_proc_tree(pid, including_parent=False)` method in `utils.py`
## Refactors:
- [x] ecm.py
- [x] ecm2.py