### PR TITLE
Improving Mac Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ If `pip3 install -r "requirements.txt"` fails to install requirements accessible
 
 ``easy_install `cat requirements.txt` ``
 
+If you installed gmpy2 with homebrew(`brew install gmp`), you might have to point clang towards the header files with this command:
+``CFLAGS=-I/opt/homebrew/include LDFLAGS=-L/opt/homebrew/lib pip3 install -r requirements.txt``
+
 ### Optional to factor roca keys upto 512 bits, Install neca:
 You can follow instructions from : `https://www.mersenneforum.org/showthread.php?t=23087`
 

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,2 +1,3 @@
 wolframalpha
 SageMath
+gmpy==1.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ six
 cryptography==3.3.2
 urllib3==1.26.5
 requests==2.25.1
-gmpy==1.17
 gmpy2==2.1.2
 pycryptodome==3.10.4
 tqdm


### PR DESCRIPTION
Easy_install is extremely old and deprecated. In order for clang to properly locate the gmpy header files using homebrew, the prefix is needed. Aditionally, I can't find a method to install the gmpy 1 package on macOS, however as it is a fallback, I would relegate it to the optional-requirements.