### PR TITLE
docs: fix typos in markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,14 @@
 - Multi ciphers support;
 - black formatting;
 - New attacks : londahl and qicheng;
-- `--dumpkey` and `--ext` now dump informations about each keys (public and private).
+- `--dumpkey` and `--ext` now dump information about each keys (public and private).
 
 ### New tests in test.sh
 
 - Hastads;
 - Unciphering multiple files;
 - Testing multiple keys against on cipher;
-- Extra informations output.
+- Extra information output.
 
 ### Fixes
 
@@ -47,7 +47,7 @@ def attack(attack_rsa_obj, publickey, cipher=[]):
     return (None, None)
 ```
 
-- attack_rsa_obj : a reference to `lib.rsa_attack.RSAAttack` instance. it gave access to cli arguments and various informations;
+- attack_rsa_obj : a reference to `lib.rsa_attack.RSAAttack` instance. it gave access to cli arguments and various information;
 - publickey : a `lib.keys_wrapper.PublicKey` instance;
 - cipher : a list containing each data to uncipher.
 
@@ -55,7 +55,7 @@ The attack method return a tuple :
 (`private_key`, `unciphered_data`)
 
 - private_key : an instance of `lib.keys_wrapper.PrivateKey` if recovered, else None. If multiple keys are recovered, return a `list` of `lib.keys_wrapper.PrivateKey`;
-- unciphered_data : if the attack focus on unciphering and not private key retreiving. If the private key is recovered, just return `None` and it will be deciphered later in script. If no data is recovered, return `None`. If multiple ciphers are recovered, return a `list` of `bytes`.
+- unciphered_data : if the attack focus on unciphering and not private key retrieving. If the private key is recovered, just return `None` and it will be deciphered later in script. If no data is recovered, return `None`. If multiple ciphers are recovered, return a `list` of `bytes`.
 
 #### Adding multiple keys attack
 
@@ -71,7 +71,7 @@ def attack(attack_rsa_obj, publickeys, cipher=[]):
     return (None, None)
 ```
 
-- attack_rsa_obj : a reference to `lib.rsa_attack.RSAAttack` instance. it gave access to cli arguments and various informations;
+- attack_rsa_obj : a reference to `lib.rsa_attack.RSAAttack` instance. it gave access to cli arguments and various information;
 - publickeys : a list of `lib.keys_wrapper.PublicKey` instance;
 - cipher : a list containing each data to uncipher.
 
@@ -79,7 +79,7 @@ The attack method return a tuple :
 (`private_key`, `unciphered_data`)
 
 - private_key : an instance of `lib.keys_wrapper.PrivateKey` if recovered, else None. If multiple keys are recovered, return a `list` of `lib.keys_wrapper.PrivateKey`;
-- unciphered_data : if the attack focus on unciphering and not private key retreiving. If the private key is recovered, just return `None` and it will be deciphered later in script. If no data is recovered, return `None`. If multiple ciphers are recovered, return a `list` of `bytes`.
+- unciphered_data : if the attack focus on unciphering and not private key retrieving. If the private key is recovered, just return `None` and it will be deciphered later in script. If no data is recovered, return `None`. If multiple ciphers are recovered, return a `list` of `bytes`.
 
 ## Ending note
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ### Contributing ###
 ```
-Contributons:
+Contributions:
     Are welcome!
     Criteria: - They should not include hidden folders or files of any ide environment.
               - They should not delete big portions of the project.
@@ -10,7 +10,7 @@ Contributons:
               - They should not include binaries.
               - They should be in small PRs for faster reviewing process.
               - They should include a small testcase.
-              - Avoid naming an algorithm after youself, no vanity is accepted (better describe what the algorithm does).
+              - Avoid naming an algorithm after yourself, no vanity is accepted (better describe what the algorithm does).
               - Any contribution not hornoring this criteria will be rejected until it does.
 ```             
 


### PR DESCRIPTION
I have fixed some typos in markdown files. Following are the fixed typos:
1. informations -> information
2. retreiving -> retrieving
3. Contributons -> Contributions
4. youself -> yourself

I kindly request the repository maintainers to review and merge it. Thanks! :heart: