### PR TITLE
Update optional-requirements.txt

### DIFF
--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,3 +1,3 @@
 wolframalpha
 SageMath
-gmpy==2.1.15
+gmpy2==2.1.5


### PR DESCRIPTION
Last updated in commit [1a3bdf9](https://github.com/RsaCtfTool/RsaCtfTool/commit/1a3bdf9f9156af196634af09796b8ea297806d1a)

Version 2.1.15 doesn't exist.

gmpy 1.17 is the final release of the 1.x series. No further updates are planned. All further development is occurring in the 2.x series, also known as gmpy2. Please see https://pypi.python.org/pypi/gmpy2/ for the latest 2.x releases.
