### PR TITLE
Fix whitespace E 302 (PEP8)

### DIFF
--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -389,6 +389,7 @@ def decrypt_file(args, logger):
     logger.error("Private key or public key and decrypted data are required.")
     return False
 
+
 def pubkey_detail(args, logger):
     for publickey in args.publickey:
         logger.info(f"Details for {publickey}:")


### PR DESCRIPTION
Fix whitespace before function violating PEP 8 leading to check failures in the following previous commits:
` edefee6, 12c44bc, 6f6b3ae, 56a71b9.`
