### PR TITLE
fix issue#466

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -10,6 +10,7 @@ import subprocess
 import contextlib
 import binascii
 import psutil
+from threading import Timer
 from lib.keys_wrapper import PublicKey
 from lib.number_theory import invmod
 
@@ -184,12 +185,16 @@ class timeout(contextlib.ContextDecorator):
         self.logger.warning("[!] Timeout.")
         raise TimeoutError(self.timeout_message)
 
-    def __enter__(self):
-        signal.signal(signal.SIGALRM, self._timeout_handler)
-        signal.alarm(self.seconds)
+    def __enter__(self):        
+        signal.signal(signal.SIGTERM, self._timeout_handler)        
+        def alarm_func():#send signal
+            signal.raise_signal(signal.SIGTERM)
+
+        self.timer = Timer(self.seconds, alarm_func)#this thread will send signal when timeout
+        self.timer.start()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        signal.alarm(0)
+        self.timer.cancel()
         if self.suppress and exc_type is TimeoutError:
             return True
 


### PR DESCRIPTION
As #466 mentioned, SIGALRM is not supported on Windows. I used SIGTERM instead. I have tested on Windows and Linux, both worked.

My testing command is:
`./RsaCtfTool.py --publickey ./examples/elite_primes.pub --private --withtraceback --attack fermat --timeout 3`

`./RsaCtfTool.py --publickey ./examples/fermat.pub --private --withtraceback --attack fermat --timeout 3`

First one will raise timeout in 3 secs, and second one can solve without timeout.