### PR TITLE
Fix some issues when longs are provided

### DIFF
--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -445,6 +445,9 @@ def main():
     if args.d is not None:
         args.d = get_numeric_value(args.d)
 
+    if args.n is not None:
+        args.n = get_numeric_value(args.n)
+
     if args.e is not None:
         e_array = []
         for e in args.e.split(","):
@@ -454,16 +457,14 @@ def main():
     elif args.n is not None:
         args.e = 65537
 
-    # get n if we can
-    if args.n is not None:
-        args.n = get_numeric_value(args.n)
-    elif args.p is not None and args.q is not None:
-        args.n = args.p * args.q
-
     if args.n is not None and (args.p is not None or args.q is not None):
         logger.warning(
             "[!] It seems you already provided one of the prime factors, nothing to do here..."
         )
+
+    # get n from p and q
+    if args.n is None and args.p is not None and args.q is not None:
+        args.n = args.p * args.q
 
     # get p and q from n, e and d
     if args.n is not None and args.e is not None and args.d is not None and args.p is None and args.q is None:

--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -385,6 +385,10 @@ def decrypt_file(args, logger):
     if args.publickey:
         return True
 
+    # Check if n and e are provided
+    if args.n and args.e:
+        return True
+
     # No private key or public key provided
     logger.error("Private key or public key and decrypted data are required.")
     return False


### PR DESCRIPTION
Issues resolved:
- When passing `--decryptfile`, the program cannot use provided longs (which was possible before #454 was merged)
- A warning message is always printed when passing `p` and `q` regardless of `n`