### PR TITLE
Updated Docker Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ For more examples, look at the test.sh file
 ### Docker run ###
 
 ```bash
-docker pull rsactftool/rsactftool
+docker build -t rsactftool/rsactftool .
 docker run -it --rm -v $PWD:/data rsactftool/rsactftool <arguments>
 ```
 


### PR DESCRIPTION
Replaced docker pull command with docker build command because image does not exist on Docker Hub.