### PR TITLE
Fix(setup.py) add support for pip install .

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,25 @@ BASE_CVS_URL = "https://github.com/RsaCtfTool/RsaCtfTool"
 
 setup(
     name="RsaCtfTool",
-    packages=[
+    py_modules=[
         "attacks",
         "lib",
     ],
     version=VERSION,
-    author="Ganapati",
+    author="Ganapati", # Original author
     author_email="something",
     install_requires=[x.strip() for x in open("requirements.txt").readlines()],
     url=BASE_CVS_URL,
     download_url=f"{BASE_CVS_URL}/tarball/{VERSION}",
     keywords=[],
     scripts=["RsaCtfTool.py"],
+    
+    entry_points={
+        'console_scripts': [
+            'rsa = RsaCtfTool:main',
+            'rsaCtfTool = RsaCtfTool:main',
+        ],
+    },
     include_package_data=True,
     classifiers=[
         "Development Status :: 1 - Planning",

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,6 @@ setup(
     install_requires=[x.strip() for x in open("requirements.txt").readlines()],
     url=BASE_CVS_URL,
     download_url=f"{BASE_CVS_URL}/tarball/{VERSION}",
-    keywords=[],
-    scripts=["RsaCtfTool.py"],
-    
     entry_points={
         'console_scripts': [
             'rsa = RsaCtfTool:main',

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,11 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 VERSION = "0.1.0"
 BASE_CVS_URL = "https://github.com/RsaCtfTool/RsaCtfTool"
 
 setup(
     name="RsaCtfTool",
-    packages=[
-        "attacks",
-        "lib",
-    ],
+    packages=find_packages(),
     py_modules=[
         "RsaCtfTool",
     ],
@@ -25,7 +22,9 @@ setup(
         ],
     },
     include_package_data=True,
+    license="MIT",
     classifiers=[
+        "License :: OSI Approved :: MIT License",
         "Development Status :: 1 - Planning",
         "Intended Audience :: Developers",
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,10 @@ BASE_CVS_URL = "https://github.com/RsaCtfTool/RsaCtfTool"
 
 setup(
     name="RsaCtfTool",
-    py_modules=[
+    packages=[
         "attacks",
+    ],
+    py_modules=[
         "lib",
     ],
     version=VERSION,

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 from setuptools import setup
 
-VERSION = "0.0.01"
+VERSION = "0.1.0"
 BASE_CVS_URL = "https://github.com/RsaCtfTool/RsaCtfTool"
 
 setup(
     name="RsaCtfTool",
     packages=[
-        "RsaCtfTool",
+        "attacks",
+        "lib",
     ],
     version=VERSION,
     author="Ganapati",
@@ -22,7 +23,6 @@ setup(
         "Intended Audience :: Developers",
         "Programming Language :: Python",
         "Operating System :: OS Independent",
-        "License :: THE BEER-WARE LICENSE",
         "Topic :: Security :: Cryptography",
     ],
     description="RSA multi attacks tool",

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,10 @@ setup(
     name="RsaCtfTool",
     packages=[
         "attacks",
+        "lib",
     ],
     py_modules=[
-        "lib",
+        "RsaCtfTool",
     ],
     version=VERSION,
     author="Ganapati", # Original author


### PR DESCRIPTION
## What does my PR solve?
Previously, if you tried to install the package using pip it would have:
- A warning regarding a deprecated license ⚠️

- An error preventing the installation 🚨

Additionally, I added a feature, when the package is installed it can be accessed through 2 CLI commands:
- rsa

- rsaCtfTool