### PR TITLE
fix: Update Dockerfile with new script name (+pathfix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /app
 COPY . .
 RUN pip install -r "requirements.txt"
 WORKDIR /data
-ENTRYPOINT ["/app/RsaCtfTool.py"]
+ENTRYPOINT ["/app/src/RsaCtfTool/main.py"]


### PR DESCRIPTION
script has been renamed and is (now?) located in the `src/RsaCtfTool` subdirectory