### PR TITLE
Adjust code-style, per flags from flake8 linter runs in CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,15 +11,15 @@ setup(
         "RsaCtfTool": ["data/*"],  # Include all files inside RsaCtfTool/data/
     },
     version=VERSION,
-    author="Ganapati", # Original author
+    author="Ganapati",  # Original author
     author_email="something",
     install_requires=[x.strip() for x in open("requirements.txt").readlines()],
     url=BASE_CVS_URL,
     download_url=f"{BASE_CVS_URL}/tarball/{VERSION}",
     entry_points={
-        'console_scripts': [
-            'rsacrack = RsaCtfTool.main:main',
-            'RsaCtfTool = RsaCtfTool.main:main',
+        "console_scripts": [
+            "rsacrack = RsaCtfTool.main:main",
+            "RsaCtfTool = RsaCtfTool.main:main",
         ],
     },
     include_package_data=True,

--- a/src/RsaCtfTool/attacks/single_key/pastctfprimes.py
+++ b/src/RsaCtfTool/attacks/single_key/pastctfprimes.py
@@ -8,7 +8,6 @@ from RsaCtfTool.lib.keys_wrapper import PrivateKey
 from RsaCtfTool.lib.number_theory import is_divisible
 
 
-
 class Attack(AbstractAttack):
     def __init__(self, timeout=60):
         super().__init__(timeout)

--- a/src/RsaCtfTool/lib/algos.py
+++ b/src/RsaCtfTool/lib/algos.py
@@ -601,7 +601,7 @@ def SQUFOF(N):
         3 * 5 * 7 * 11,
     ]
 
-    if (n - 2) & 3 == 0:  # Congruence n = 2 (mod 4).
+    if (N - 2) & 3 == 0:  # Congruence n = 2 (mod 4).
         raise FactorizationError
 
     s = isqrt(N)

--- a/src/RsaCtfTool/lib/algos.py
+++ b/src/RsaCtfTool/lib/algos.py
@@ -8,7 +8,33 @@ from random import randint
 from tqdm import tqdm
 from itertools import count
 from RsaCtfTool.lib.exceptions import FactorizationError
-from RsaCtfTool.lib.number_theory import isqrt, gcd, primes, powmod, is_square, powmod_base_list, next_prime, A000265, isqrt_rem, inv_mod_pow_of_2, trivial_factorization_with_n_phi, cuberoot, mod, log, ilog10, ilog2, fib, rational_to_contfrac, convergents_from_contfrac, fdivmod, is_congruent, is_divisible, ilogb, mlucas, iroot  # , is_prime, invert, contfrac_to_rational
+from RsaCtfTool.lib.number_theory import (
+    isqrt,
+    gcd,
+    primes,
+    powmod,
+    is_square,
+    powmod_base_list,
+    next_prime,
+    A000265,
+    isqrt_rem,
+    inv_mod_pow_of_2,
+    trivial_factorization_with_n_phi,
+    cuberoot,
+    mod,
+    log,
+    ilog10,
+    ilog2,
+    fib,
+    rational_to_contfrac,
+    convergents_from_contfrac,
+    fdivmod,
+    is_congruent,
+    is_divisible,
+    ilogb,
+    mlucas,
+    iroot,
+)  # , is_prime, invert, contfrac_to_rational
 from RsaCtfTool.lib.number_theory import invmod, introot
 
 sys.setrecursionlimit(100000)
@@ -105,7 +131,8 @@ def dixon(N, B=7):
     QBF = bitarray.bitarray(lqbf)  # This is our quasi-bloom-filter
 
     basej2N = powmod_base_list(base, 2, N)
-    for p in basej2N: QBF[p] = 1
+    for p in basej2N:
+        QBF[p] = 1
 
     for i in range(isqrt(N), N):
         i2N = powmod(i, 2, N)
@@ -200,14 +227,14 @@ def factor_XYXZ(n, base=3):
     power = 1
     max_power = (int(log(n) / log(base)) + 1) >> 1
     while power <= max_power:
-        p = next_prime(base ** power)
+        p = next_prime(base**power)
         if is_divisible(n, p):
             return p, n // p
         power += 1
 
 
 def fermat(n):
-    if (n-2) & 3 == 0: # Congruence n = 2 (mod 4).
+    if (n - 2) & 3 == 0:  # Congruence n = 2 (mod 4).
         raise FactorizationError
     a, rem = isqrt_rem(n)
     b2 = -rem
@@ -239,7 +266,7 @@ def FactorHighAndLowBitsEqual(n, max_middle_bits=24):
     Code taken and heavy modified from https://github.com/google/paranoid_crypto/blob/main/paranoid_crypto/lib/rsa_util.py
     Licensed under open source Apache License Version 2.0, January 2004.
     """
-    if ((n_size:=n.bit_length()) < 6) or (n & 7 != 1):
+    if ((n_size := n.bit_length()) < 6) or (n & 7 != 1):
         return None
     k = (n_size + 1) >> 1
     r0 = InverseInverseSqrt2exp(n, k + 1)
@@ -247,7 +274,7 @@ def FactorHighAndLowBitsEqual(n, max_middle_bits=24):
         raise ArithmeticError("expecting that square root exists")
     a = isqrt(n - 1) + 1
 
-    for middle_bits in range(1, max_middle_bits+1):
+    for middle_bits in range(1, max_middle_bits + 1):
         print(f"middle bits: {middle_bits} of {n_size}/2")
         for r in [r0, (1 << k) - r0]:
             s = a
@@ -334,7 +361,11 @@ class Fibonacci:
                             # )
                             print(
                                 "For N = %d\n Found res: %d, res_n: %d\n but failed!"
-                                % (N, res, res_n,)
+                                % (
+                                    N,
+                                    res,
+                                    res_n,
+                                )
                             )
 
     def factorization(self, N, min_accept, xdiff):
@@ -402,12 +433,12 @@ def lehmer_machine(n):
     """
     fermat based integer factorization
     """
-    if (n-2) & 3 == 0: # Congruence n = 2 (mod 4).
+    if (n - 2) & 3 == 0:  # Congruence n = 2 (mod 4).
         raise FactorizationError
     y = 1
-    while not is_square(n + y ** 2):
+    while not is_square(n + y**2):
         y += 1
-    x = isqrt(n + y ** 2)
+    x = isqrt(n + y**2)
     return x - y, x + y
 
 
@@ -530,9 +561,14 @@ def shor(n):
     """
     for a in range(2, n):
         # a should be coprime of n otherwise it is a trivial factor of n.
-        if (g := gcd(n, a)) != 1: return g, n // g
-        for r in range(2, n, 2):  # from this step is that it shoul be run in a quantum computer, but we are doing a linear search.
-            if (ar := powmod(a, r, n)) == 1:  # ar is the period returned by the quantum computer, we are just bruteforcing it.
+        if (g := gcd(n, a)) != 1:
+            return g, n // g
+        for r in range(
+            2, n, 2
+        ):  # from this step is that it shoul be run in a quantum computer, but we are doing a linear search.
+            if (
+                ar := powmod(a, r, n)
+            ) == 1:  # ar is the period returned by the quantum computer, we are just bruteforcing it.
                 if (ar2 := powmod(a, r >> 1, n)) != -1:
                     g1, g2 = gcd(ar2 - 1, n), gcd(ar2 + 1, n)
                     if (n > g1 > 1) or (n > g2 > 1):
@@ -565,7 +601,7 @@ def SQUFOF(N):
         3 * 5 * 7 * 11,
     ]
 
-    if (n-2) & 3 == 0: # Congruence n = 2 (mod 4).
+    if (n - 2) & 3 == 0:  # Congruence n = 2 (mod 4).
         raise FactorizationError
 
     s = isqrt(N)
@@ -606,18 +642,18 @@ def SQUFOF(N):
 
 
 def pollard_strassen(n):
-  """
-  https://math.stackexchange.com/questions/185524/pollard-strassen-algorithm
-  """
-  f,c =[], iroot(n,4)[0]
-  for i in range(0, c):
-    f.append(1)
-    jmin = i * c + 1
-    jmax = jmin + c - 1
-    for j in range(jmin, jmax + 1):
-      f[i] = (f[i] * j) % n
-      if (g:=gcd(f[i], n))>1:
-        return g, n//g
+    """
+    https://math.stackexchange.com/questions/185524/pollard-strassen-algorithm
+    """
+    f, c = [], iroot(n, 4)[0]
+    for i in range(0, c):
+        f.append(1)
+        jmin = i * c + 1
+        jmax = jmin + c - 1
+        for j in range(jmin, jmax + 1):
+            f[i] = (f[i] * j) % n
+            if (g := gcd(f[i], n)) > 1:
+                return g, n // g
 
 
 def wiener(n, e, progress=True):
@@ -663,14 +699,18 @@ def difference_of_powers_factor(n):
     F = set()
     for a in range(2, isqrt(n) + 1):
         a_k = a
-        for k in range(1, int(log(n)/log(a)) + 1):
-            if (1 << k) > n: break
+        for k in range(1, int(log(n) / log(a)) + 1):
+            if (1 << k) > n:
+                break
             a_k *= a
-            if a_k > n: break  
+            if a_k > n:
+                break
             for sign in [-1, 1]:
                 if (b_k := a_k + sign * n) > 0:
                     b, e = iroot(b_k, k)
                     if e and b > 1:
-                        if 1 < (f1 := gcd(a - b, n)) < n: F.add(f1)
-                        if 1 < (f2 := gcd(a + b, n)) < n: F.add(f2)
+                        if 1 < (f1 := gcd(a - b, n)) < n:
+                            F.add(f1)
+                        if 1 < (f2 := gcd(a + b, n)) < n:
+                            F.add(f2)
     return sorted(F)

--- a/src/RsaCtfTool/lib/external.py
+++ b/src/RsaCtfTool/lib/external.py
@@ -14,7 +14,7 @@ def ifferm(fname):
 
 
 def msieve_factor_driver(n):
-    global MSIEVE_BIN
+    # global MSIEVE_BIN  # `global` not required for read-only use (F824)
     print("[*] Factoring %d with msieve..." % n)
     tmp = []
     proc = subprocess.Popen(
@@ -30,7 +30,7 @@ def msieve_factor_driver(n):
 
 
 def yafu_factor_driver(n):
-    global YAFU_BIN, TIMEOUT
+    # global YAFU_BIN, TIMEOUT # `global` not required for read-only use (F824)
     print("[*] Factoring %d with yafu..." % n)
     tmp = []
     proc = subprocess.Popen(

--- a/src/RsaCtfTool/lib/number_theory.py
+++ b/src/RsaCtfTool/lib/number_theory.py
@@ -32,8 +32,9 @@ except ImportError:
 
 @cache
 def list_prod(list_):
-    if (l := len(list_)) == 0: return 1
-    return list_prod(list_[:l - 1]) * list_[-1]
+    if (l := len(list_)) == 0:
+        return 1
+    return list_prod(list_[: l - 1]) * list_[-1]
 
 
 digit_sum = lambda n: sum(int(d) for d in str(n))
@@ -44,10 +45,14 @@ A000265 = lambda n: n // (A135481(n) + 1)
 
 @cache
 def mulmod(a, b, m):
-    if b == 0: return 0
-    if b == 1: return a % m
-    if b & 1 == 0: return mulmod((a << 1) % m, b >> 1, m)
-    else: return (a + mulmod(a, b - 1, m)) % m
+    if b == 0:
+        return 0
+    if b == 1:
+        return a % m
+    if b & 1 == 0:
+        return mulmod((a << 1) % m, b >> 1, m)
+    else:
+        return (a + mulmod(a, b - 1, m)) % m
 
 
 def getpubkeysz(n):
@@ -167,20 +172,24 @@ def miller_rabin(n, k=40):
     for justification
     """
 
-    if n == 2: return True
-    if (n & 1 == 0) or (digit_sum(n) % 9 in [0, 3, 6]): return False
+    if n == 2:
+        return True
+    if (n & 1 == 0) or (digit_sum(n) % 9 in [0, 3, 6]):
+        return False
 
     r, s = 0, n - 1
-    while (s & 1 == 0):
+    while s & 1 == 0:
         r += 1
         s >>= 1
     i = 0
     for _ in range(0, k):
         a = random.randrange(2, n - 1)
-        if (x := pow(a, s, n)) in [1, n - 1]: continue
+        if (x := pow(a, s, n)) in [1, n - 1]:
+            continue
         j = 0
-        while (j <= r - 1):
-            if (x := pow(x, 2, n)) == (n - 1): break
+        while j <= r - 1:
+            if (x := pow(x, 2, n)) == (n - 1):
+                break
             j += 1
         else:
             return False
@@ -309,8 +318,10 @@ def _fac(n):
 
 @cache
 def _lucas(n):
-    if n == 0: return 2
-    if n == 1: return 1
+    if n == 0:
+        return 2
+    if n == 1:
+        return 1
     return _lucas(n - 1) + _lucas(n - 2)
 
 
@@ -622,13 +633,14 @@ def is_lucas(n):
     True if n is a Lucas number (A000032).
     """
     sign = lambda n: 1 if n > 0 else -1
-    u1,u2 = 1,3
-    if n<=2: return sign(n)
+    u1, u2 = 1, 3
+    if n <= 2:
+        return sign(n)
     else:
-        while(n>u2):
-            old_u1,u1=u1,u2
-            u2=old_u1+u2
-    return u2==n
+        while n > u2:
+            old_u1, u1 = u1, u2
+            u2 = old_u1 + u2
+    return u2 == n
 
 
 __all__ = [

--- a/src/RsaCtfTool/lib/rsa_attack.py
+++ b/src/RsaCtfTool/lib/rsa_attack.py
@@ -132,14 +132,12 @@ class RSAAttack(object):
                 ok = False
         return (tmp, ok)
 
-    
     def get_attack(self, attack, multikeys):
         if multikeys:
             import_path = f"RsaCtfTool.attacks.multi_keys.{attack}"
         else:
             import_path = f"RsaCtfTool.attacks.single_key.{attack}"
         return importlib.import_module(import_path, package="RsaCtfTool")
-
 
     def load_attacks(self, attacks_list, multikeys=False):
         """Dynamic load attacks according to context (single key or multiple keys)"""
@@ -157,7 +155,7 @@ class RSAAttack(object):
             if attack in self.args.attack or "all" in self.args.attack:
 
                 try:
-                    attack_module =self.get_attack(attack, multikeys)
+                    attack_module = self.get_attack(attack, multikeys)
                     # Dynamically add named-arguments to constructor if same sys.argv exists
                     expected_args = list(
                         inspect.getfullargspec(attack_module.Attack.__init__).args
@@ -180,7 +178,7 @@ class RSAAttack(object):
                         attack_module.Attack(**constructor_args)
                     )
                 except ModuleNotFoundError:
-                    #print(f"[-] Attack {attack} not found...")
+                    # print(f"[-] Attack {attack} not found...")
                     pass
         self.implemented_attacks.sort(key=lambda x: x.speed, reverse=True)
 

--- a/src/RsaCtfTool/lib/system_primes.py
+++ b/src/RsaCtfTool/lib/system_primes.py
@@ -1299,7 +1299,8 @@ a0e03b4dae2af5b0c8ebbb3c83539961
 
 def load_system_consts():
     addpm1 = lambda n: [n - 1, n, n + 1] if n > 2 else [n, n + 1]
-    global primes_txt, notprimes_txt, primes_int, primes_txt_arry
+    global primes_int
+    # global primes_txt, notprimes_txt, primes_txt_arry # `global` not required for read-only use (F824)
     primes_tmp0 = primes_txt
     primes_tmp0 = map(lambda x: x.replace("\n", ""), primes_tmp0)
     primes_tmp0 = map(lambda x: x.replace(" ", ""), primes_tmp0)

--- a/src/RsaCtfTool/lib/utils.py
+++ b/src/RsaCtfTool/lib/utils.py
@@ -29,7 +29,7 @@ def get_numeric_value(value):
 def get_base64_value(value):
     """Parse input (hex or numerical)"""
     try:
-        if (base64.b64encode(d := base64.b64decode(value)) == value):
+        if base64.b64encode(d := base64.b64decode(value)) == value:
             return d
         else:
             return value
@@ -126,7 +126,9 @@ def print_results(args, publickey, private_key, decrypt):
                 for public_key in args.publickey:
                     with open(public_key, "rb") as pubkey_fd:
                         publickey_obj = PublicKey(pubkey_fd.read(), publickey)
-                        logger.info("\nPublic key details for %s" % publickey_obj.filename)
+                        logger.info(
+                            "\nPublic key details for %s" % publickey_obj.filename
+                        )
                         logger.info(f"n: {str(publickey_obj.n)}")
                         logger.info(f"e: {str(publickey_obj.e)}")
 
@@ -185,12 +187,15 @@ class timeout(contextlib.ContextDecorator):
         self.logger.warning("[!] Timeout.")
         raise TimeoutError(self.timeout_message)
 
-    def __enter__(self):        
-        signal.signal(signal.SIGTERM, self._timeout_handler)        
-        def alarm_func():#send signal
+    def __enter__(self):
+        signal.signal(signal.SIGTERM, self._timeout_handler)
+
+        def alarm_func():  # send signal
             signal.raise_signal(signal.SIGTERM)
 
-        self.timer = Timer(self.seconds, alarm_func)#this thread will send signal when timeout
+        self.timer = Timer(
+            self.seconds, alarm_func
+        )  # this thread will send signal when timeout
         self.timer.start()
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
This PR includes fxes for 51x linter issues [flagged in CI](https://github.com/RsaCtfTool/RsaCtfTool/actions/runs/14247924835/job/39933475095):

* Formatted files containinf 44x whitespace issues (below) using [Black](https://pypi.org/project/black/)
  * 5     E111 indentation is not a multiple of 4
  * 10    E225 missing whitespace around operator
  * 7     E226 missing whitespace around arithmetic operator
  * 7     E231 missing whitespace after ','
  * 6     E261 at least two spaces before inline comment
  * 2     E262 inline comment should start with '# '
  * 1     E265 block comment should start with '# '
  * 1     E275 missing whitespace after keyword
  * 3     E303 too many blank lines (3)
  * 1     E306 expected 1 blank line before a nested definition, found 0
  * 1     W293 blank line contains whitespace
* fixed var-name typo (`n` instead of `N`)
  * 1     F821 undefined name 'n'
* commented-out `global` declaration for variables used in a read-only capacity
  * 6     F824 `global X` is unused: name is never assigned in scope
