### PR TITLE
Revert "Reduce cyclomatic complexity and remove dead code"

### DIFF
--- a/src/RsaCtfTool/attacks/single_key/brent.py
+++ b/src/RsaCtfTool/attacks/single_key/brent.py
@@ -37,6 +37,8 @@ class Attack(AbstractAttack):
         except TypeError:
             return None, None
 
+        return None, None
+
     def test(self):
         from RsaCtfTool.lib.keys_wrapper import PublicKey
 

--- a/src/RsaCtfTool/attacks/single_key/pollard_rho.py
+++ b/src/RsaCtfTool/attacks/single_key/pollard_rho.py
@@ -23,6 +23,8 @@ class Attack(AbstractAttack):
         except TypeError:
             return None, None
 
+        return None, None
+
     def test(self):
         from RsaCtfTool.lib.keys_wrapper import PublicKey
 

--- a/src/RsaCtfTool/attacks/single_key/z3_solver.py
+++ b/src/RsaCtfTool/attacks/single_key/z3_solver.py
@@ -86,6 +86,8 @@ class Attack(AbstractAttack):
         else:
             return None, None
 
+        return None, None
+
     def test(self):
         from RsaCtfTool.lib.keys_wrapper import PublicKey
 

--- a/src/RsaCtfTool/lib/external.py
+++ b/src/RsaCtfTool/lib/external.py
@@ -1,7 +1,55 @@
 import os
 import subprocess
+import re
 
+TIMEOUT = 600
+MSIEVE_BIN = os.environ.get("MSIEVE_BIN", "NONE")
+YAFU_BIN = os.environ.get("YAFU_BIN", "NONE")
+CADO_BIN = os.environ.get("CADO_BIN", "NONE")
 NECA_BIN = os.environ.get("NECA_BIN", "NONE")
+
+
+def ifferm(fname):
+    os.system(f"if [ -f '{fname}' ];  then rm '{fname}'; fi")
+
+
+def msieve_factor_driver(n):
+    print("[*] Factoring %d with msieve..." % n)
+    tmp = []
+    proc = subprocess.Popen(
+        [MSIEVE_BIN, "-s", "/tmp/%d.dat" % n, "-t", "8", "-v", str(n)],
+        stdout=subprocess.PIPE,
+    )
+    for line in proc.stdout:
+        line = line.rstrip().decode("utf8")
+        if re.search("factor: ", line):
+            tmp += [int(line.split()[2])]
+    ifferm("/tmp/%d.dat" % n)
+    return tmp
+
+
+def yafu_factor_driver(n):
+    print("[*] Factoring %d with yafu..." % n)
+    tmp = []
+    proc = subprocess.Popen(
+        [
+            "timeout",
+            str(TIMEOUT),
+            YAFU_BIN,
+            f"factor({str(n)})",
+            "-session",
+            str(n),
+            "-qssave",
+            f"/tmp/qs_{str(n)}.dat",
+        ],
+        stdout=subprocess.PIPE,
+    )
+    for line in proc.stdout:
+        line = line.rstrip().decode("utf8")
+        if re.search(r"P\d+ = \d+", line):
+            tmp += [int(line.split("=")[1])]
+    ifferm("/tmp/qs_%d.dat" % n)
+    return tmp
 
 
 def neca_factor_driver(n, timeout=None):
@@ -18,4 +66,12 @@ def neca_factor_driver(n, timeout=None):
                 return list(map(int, line.split("=")[1].split("*")))
 
 
+def cado_factor_driver(n):
+    return
 
+
+def external_factorization(n):
+    factors = yafu_factor_driver(n)
+    if len(factors) == 0:
+        factors = msieve_factor_driver(n)
+    return factors

--- a/src/RsaCtfTool/lib/keys_wrapper.py
+++ b/src/RsaCtfTool/lib/keys_wrapper.py
@@ -86,84 +86,6 @@ class PublicKey(object):
 
 
 class PrivateKey(object):
-    def _init_fields(self, p, q, e, n, d, phi):
-        self.p = p
-        self.q = q
-        self.e = e
-        self.n = n
-        self.d = d
-        self.phi = phi
-
-    def _compute_phi(self):
-        if self.p is not None and self.q is not None and self.phi is None:
-            if self.p != self.q:
-                self.phi = (self.p - 1) * (self.q - 1)
-            else:
-                self.phi = (self.p ** 2) - self.p
-
-    def _compute_d(self, e):
-        if self.d is not None:
-            return
-        if self.phi is not None and self.e is not None:
-            try:
-                self.d = int(invert(e, self.phi))
-            except ValueError:
-                logger.error("[!] e^d==1 inversion error, check your math.")
-
-    def _construct_key_from_components(self):
-        if self.p is not None and self.q is not None and self.d is not None:
-            try:
-                self.key = RSA.construct((self.n, self.e, self.d, self.p, self.q))
-            except ValueError:
-                logger.error("[!] Can't construct RSA PEM, internal error....")
-            return True
-        if self.n is not None and self.e is not None and self.d is not None:
-            try:
-                self.key = RSA.construct((self.n, self.e, self.d))
-            except NotImplementedError:
-                logger.error("[!] Unable to create PEM private key...")
-                logger.info(
-                    "n:%s\ne:%s\nd:%s\n" % (hex(self.n), hex(self.e), hex(self.d))
-                )
-            except ValueError:
-                logger.error("[!] Unable to compute factors p and q from exponent d")
-                logger.info("[+] n=%d,e=%d,d=%d" % (self.n, self.e, self.d))
-            return True
-        return False
-
-    def _load_key_from_file(self, filename, password, p, q, d):
-        with open(filename, "rb") as key_data_fd:
-            try:
-                self.key = serialization.load_pem_private_key(
-                    key_data_fd.read(), password=password, backend=default_backend()
-                )
-                private_numbers = self.key.private_numbers()
-                loadok = True
-            except Exception:
-                loadok = False
-
-            if loadok:
-                if p is None:
-                    self.p = private_numbers.p
-                if q is None:
-                    self.q = private_numbers.q
-                if d is None:
-                    self.d = private_numbers.d
-                if self.p and self.q:
-                    self.n = self.p * self.q
-                self._compute_phi()
-            else:
-                tmp = load_partial_privkey(filename)
-                self.n = tmp[1]
-                self.e = tmp[2]
-                self.d = tmp[3]
-                self.p = tmp[4]
-                self.q = tmp[5]
-                self.dp = tmp[6]
-                self.dq = tmp[7]
-                self.di = tmp[8]
-                self.filename = filename
-
     def __init__(
         self,
         p=None,
@@ -181,12 +103,94 @@ class PrivateKey(object):
         :param e: exponent
         :param n: n from public key
         """
+        self.p = None
+        if p is not None:
+            self.p = p
+
+        self.q = None
+        if q is not None:
+            self.q = q
+
+        self.e = None
+        if e is not None:
+            self.e = e
+
+        self.n = None
+        if n is not None:
+            self.n = n
+
+        self.phi = None
+        if phi is not None:
+            self.phi = phi
+
+        if self.p is not None and self.q is not None and self.phi is None:
+            if self.p != self.q:
+                self.phi = (self.p - 1) * (self.q - 1)
+            else:
+                self.phi = (self.p**2) - self.p
+
+        if d is not None:
+            self.d = d
+        elif self.phi is not None and self.e is not None:
+            try:
+                self.d = int(invert(e, self.phi))
+            except ValueError:
+                # invmod failure
+                logger.error("[!] e^d==1 inversion error, check your math.")
         self.key = None
-        self._init_fields(p, q, e, n, d, phi)
-        self._compute_phi()
-        self._compute_d(e)
-        if not self._construct_key_from_components() and filename is not None:
-            self._load_key_from_file(filename, password, p, q, d)
+        if self.p is not None and self.q is not None and self.d is not None:
+            try:
+                # There is no CRT coefficient to construct a key if p equals q
+                self.key = RSA.construct((self.n, self.e, self.d, self.p, self.q))
+            except ValueError:
+                logger.error("[!] Can't construct RSA PEM, internal error....")
+        elif n is not None and e is not None and d is not None:
+            try:
+                self.key = RSA.construct((self.n, self.e, self.d))
+            except NotImplementedError:
+                logger.error("[!] Unable to create PEM private key...")
+                logger.info(
+                    "n:%s\ne:%s\nd:%s\n" % (hex(self.n), hex(self.e), hex(self.d))
+                )
+            except ValueError:
+                logger.error("[!] Unable to compute factors p and q from exponent d")
+                logger.info("[+] n=%d,e=%d,d=%d" % (self.n, self.e, self.d))
+        elif filename is not None:
+            with open(filename, "rb") as key_data_fd:
+                try:
+                    self.key = serialization.load_pem_private_key(
+                        key_data_fd.read(), password=password, backend=default_backend()
+                    )
+                    private_numbers = self.key.private_numbers()
+                    loadok = True
+                except Exception:
+                    loadok = False
+
+                if loadok:
+                    if p is None:
+                        self.p = private_numbers.p
+                    if q is None:
+                        self.q = private_numbers.q
+                    if d is None:
+                        self.d = private_numbers.d
+                    if self.p and self.q:
+                        self.n = self.p * self.q
+                    if self.phi is None:
+                        if self.p != self.q:
+                            self.phi = (self.p - 1) * (self.q - 1)
+                        else:
+                            self.phi = (self.p**2) - self.p
+                else:
+                    tmp = load_partial_privkey(filename)
+                    self.n = tmp[1]
+                    self.e = tmp[2]
+                    self.d = tmp[3]
+                    self.p = tmp[4]
+                    self.q = tmp[5]
+                    self.dp = tmp[6]
+                    self.dq = tmp[7]
+                    self.di = tmp[8]
+                    self.filename = filename
 
     def is_conspicuous(self):
         is_con, txt = privatekey_check(self.n, self.p, self.q, self.d, self.e)

--- a/src/RsaCtfTool/lib/number_theory.py
+++ b/src/RsaCtfTool/lib/number_theory.py
@@ -104,6 +104,11 @@ def _isqrt_rem(n):
     return i2, n - (i2 * i2)
 
 
+def _isqrt_rem_gmpy(n):
+    i2 = _isqrt_gmpy(n)
+    return i2, n - (i2 * i2)
+
+
 def _gcd(a, b):
     while b:
         a, b = b, a % b
@@ -256,6 +261,14 @@ def erathostenes_sieve(n):
 _primes = erathostenes_sieve
 
 
+def _primes_yield(n):
+    p = i = 1
+    while i <= n:
+        p = next_prime(p)
+        yield p
+        i += 1
+
+
 def _primes_yield_gmpy(n):
     p = i = 1
     while i <= n:
@@ -286,6 +299,14 @@ def ilogb(x, b):
 
 def _primes_gmpy(n):
     return list(_primes_yield_gmpy(n))
+
+
+def _isqrt_gmpy(n):
+    return int(gmpy.sqrt(n))
+
+
+def _invert(a, b):
+    return pow(a, b - 2, b)
 
 
 def _lcm(x, y):
@@ -453,6 +474,33 @@ def legendre(a, p):
 
 def cuberoot(n):
     return introot(n, 3)
+
+
+def factor_ned_probabilistic(n, e, d):
+    """
+    800-56B R1 Recommendation for Pair-Wise Key Establishment Schemes Using Integer Factorization Cryptography in Appendix C.
+    """
+    n1, k = n - 1, d * e - 1
+    if k & 1 == 1:
+        return
+    t, r = 0, k
+    while r & 1 == 0:
+        r >>= 1
+        t += 1
+    for _ in range(1, 101):
+        g = random.randint(0, n1)
+        if (y := pow(g, r, n)) == 1 or y == n1:
+            continue
+        for _ in range(1, t):
+            if (x := pow(y, 2, n)) == 1:
+                p = gcd(y - 1, n)
+                return p, n // p
+            if x == n1:
+                continue
+            y = x
+        if (x := pow(y, 2, n)) == 1:
+            p = gcd(x - 1, n)
+            return p, n // p
 
 
 def trivial_factorization_with_n_b(n, b):

--- a/src/RsaCtfTool/lib/pickling.py
+++ b/src/RsaCtfTool/lib/pickling.py
@@ -19,6 +19,13 @@ def safe_load(file_obj):
     return SafeUnpickler(file_obj).load()
 
 
+# Pickle a file and then compress it into a file with extension
+def compress_pickle(filename, data):
+    sys.stderr.write("saving pickle %s...\n" % filename)
+    with bz2.BZ2File(filename, "w") as f:
+        cPickle.dump(data, f)
+
+
 # Load any compressed pickle file
 def decompress_pickle(filename):
     sys.stderr.write("loading pickle %s...\n" % filename)

--- a/src/RsaCtfTool/lib/rsa_attack.py
+++ b/src/RsaCtfTool/lib/rsa_attack.py
@@ -245,96 +245,85 @@ class RSAAttack(object):
         self.priv_key_send2fdb()
         return self.get_boolean_results()
 
-    def _attack_test_mode(self, attacks_list):
-        num_attacks = len(attacks_list)
-        self.load_attacks(attacks_list, multikeys=True)
-        T = []
-        for c, attack in enumerate(self.implemented_attacks, start=1):
-            t0 = time.time()
-            if attack.can_run():
-                self.logger.info(
-                    "[*] %d of %d, Testing: %s"
-                    % (c, num_attacks, attack.get_name())
-                )
-                try:
-                    try:
-                        if attack.test():
-                            self.logger.info("[*] Success")
-                        else:
-                            self.logger.error("[!] Failure")
-                    except NotImplementedError:
-                        self.logger.warning("[!] Test not implemented")
-                except Exception:
-                    self.logger.error("[!] Failure")
-            t1 = time.time()
-            td = t1 - t0
-            T += [td]
-            self.logger.info("[+] Time elapsed: %.4f sec." % round(td, 4))
-        if len(T) > 0:
-            tmin, tmax, tavg = min(T), max(T), sum(T) / len(T)
-            self.logger.info(
-                "[+] Total time elapsed min,max,avg: %.4f/%.4f/%.4f sec."
-                % (round(tmin, 4), round(tmax, 4), round(tavg, 4))
-            )
+    def attack_single_key(self, publickey, attacks_list=[], test=False):
+        """Run attacks on single keys"""
 
-    def _load_public_key(self, publickey):
+        num_attacks = len(attacks_list)
+        if num_attacks == 0:
+            self.args.attack = "all"
+
+        self.load_attacks(attacks_list)
+        T = []
+        if test:
+            self.load_attacks(attacks_list, multikeys=True)
+            for c, attack in enumerate(self.implemented_attacks, start=1):
+                t0 = time.time()
+                if attack.can_run():
+                    self.logger.info(
+                        "[*] %d of %d, Testing: %s"
+                        % (c, num_attacks, attack.get_name())
+                    )
+                    try:
+                        try:
+                            if attack.test():
+                                self.logger.info("[*] Success")
+                            else:
+                                self.logger.error("[!] Failure")
+                        except NotImplementedError:
+                            self.logger.warning("[!] Test not implemented")
+                    except Exception:
+                        self.logger.error("[!] Failure")
+                t1 = time.time()
+                td = t1 - t0
+                T += [td]
+                self.logger.info("[+] Time elapsed: %.4f sec." % round(td, 4))
+            if len(T) > 0:
+                tmin, tmax, tavg = min(T), max(T), sum(T) / len(T)
+                self.logger.info(
+                    "[+] Total time elapsed min,max,avg: %.4f/%.4f/%.4f sec."
+                    % (round(tmin, 4), round(tmax, 4), round(tavg, 4))
+                )
+            return
+
         if isinstance(publickey, str):
+            # Read keyfile
             try:
                 with open(publickey, "rb") as pubkey_fd:
                     self.publickey = PublicKey(pubkey_fd.read(), filename=publickey)
             except Exception as e:
                 self.logger.error(f"[!] {e}.")
-                return False
+                return
             if self.args.check_publickey:
                 k, ok = self.pre_attack_check(self.publickey)
                 if not ok:
                     return False
+            # Read n/e from publickey file
             if not self.args.n or not self.args.e:
                 self.args.n = self.publickey.n
                 self.args.e = self.publickey.e
         else:
             self.publickey = publickey
-        return True
 
-    def _handle_provided_primes(self):
+        if is_prime(self.publickey.n):
+            self.logger.warning(
+                "[!] Your provided modulus is prime:\n%d\nThere is no need to run an integer factorization..."
+                % self.publickey.n
+            )
+            return True
+
         if self.args.p is not None and self.args.q is None:
             self.args.q = self.args.n // self.args.p
+
         if self.args.q is not None and self.args.p is None:
             self.args.p = self.args.n // self.args.q
+
         self.need_run = self.args.p is None or self.args.q is None
-        if self.args.show_modulus:
+
+        if self.args.show_modulus is not None and self.args.show_modulus:
             print("modulus:", self.args.n)
 
-    def _execute_single_attack(self, attack_module):
-        if not attack_module.can_run():
-            return False
-        if self.need_run:
-            self.priv_key, decrypted = attack_module.attack_wrapper(
-                self.publickey, self.cipher
-            )
-        else:
-            self.logger.warning(
-                "[!] No need to factorize since you provided a prime factor..."
-            )
-            decrypted = None
-            self.priv_key = PrivateKey(
-                self.args.p, self.args.q, self.args.e, self.args.n
-            )
-        if decrypted is not None and decrypted != []:
-            if isinstance(decrypted, list):
-                self.decrypted = self.decrypted + decrypted
-            else:
-                self.decrypted.append(decrypted)
-        if self.can_stop_tests():
-            if self.need_run:
-                self.logger.info(
-                    f"[*] Attack success with {attack_module.get_name()} method !"
-                )
-            return True
-        return False
-
-    def _run_attack_loop(self, publickey):
         T = []
+        # Loop through implemented attack methods and conduct attacks
         for attack_module in self.implemented_attacks:
             t0 = time.time()
             if self.need_run:
@@ -342,7 +331,32 @@ class RSAAttack(object):
                     f"[*] Performing {attack_module.get_name()} attack on {self.publickey.filename}."
                 )
             try:
-                if self._execute_single_attack(attack_module):
+                if not attack_module.can_run():
+                    continue
+
+                if self.need_run:
+                    self.priv_key, decrypted = attack_module.attack_wrapper(
+                        self.publickey, self.cipher
+                    )
+                else:
+                    self.logger.warning(
+                        "[!] No need to factorize since you provided a prime factor..."
+                    )
+                    decrypted = None
+                    self.priv_key = PrivateKey(
+                        self.args.p, self.args.q, self.args.e, self.args.n
+                    )
+
+                if decrypted is not None and decrypted != []:
+                    if isinstance(decrypted, list):
+                        self.decrypted = self.decrypted + decrypted
+                    else:
+                        self.decrypted.append(decrypted)
+                if self.can_stop_tests():
+                    if self.need_run:
+                        self.logger.info(
+                            f"[*] Attack success with {attack_module.get_name()} method !"
+                        )
                     break
             except TimeoutError:
                 self.logger.warning("Timeout")
@@ -369,30 +383,6 @@ class RSAAttack(object):
                 "[+] Total time elapsed min,max,avg: %.4f/%.4f/%.4f sec."
                 % (round(tmin, 4), round(tmax, 4), round(tavg, 4))
             )
-
-    def attack_single_key(self, publickey, attacks_list=[], test=False):
-        """Run attacks on single keys"""
-        num_attacks = len(attacks_list)
-        if num_attacks == 0:
-            self.args.attack = "all"
-
-        self.load_attacks(attacks_list)
-        if test:
-            self._attack_test_mode(attacks_list)
-            return
-
-        if not self._load_public_key(publickey):
-            return
-
-        if is_prime(self.publickey.n):
-            self.logger.warning(
-                "[!] Your provided modulus is prime:\n%d\nThere is no need to run an integer factorization..."
-                % self.publickey.n
-            )
-            return True
-
-        self._handle_provided_primes()
-        self._run_attack_loop(publickey)
         self.print_results_details(publickey)
         self.priv_key_send2fdb()
         return self.get_boolean_results()

--- a/src/RsaCtfTool/lib/system_primes.py
+++ b/src/RsaCtfTool/lib/system_primes.py
@@ -1,6 +1,7 @@
 primes_txt = []
 notprimes_txt = []
 primes_int = []
+notprimes_int = []
 primes_txt_arry = []
 
 # SRP rfc5054

--- a/src/RsaCtfTool/lib/timeout.py
+++ b/src/RsaCtfTool/lib/timeout.py
@@ -13,7 +13,7 @@ class timeout:
         self.seconds = seconds
         self.error_message = error_message
 
-    def handle_timeout(self, _signum, _frame):
+    def handle_timeout(self, signum, frame):
         raise FactorizationError(self.error_message)
 
     def __enter__(self):

--- a/src/RsaCtfTool/lib/utils.py
+++ b/src/RsaCtfTool/lib/utils.py
@@ -6,7 +6,9 @@ import errno
 import signal
 import base64
 import logging
+import subprocess
 import contextlib
+import binascii
 import psutil
 from threading import Timer
 from RsaCtfTool.lib.keys_wrapper import PublicKey
@@ -35,6 +37,16 @@ def get_base64_value(value):
         return value
 
 
+def sageworks():
+    """Check if sage is installed and working"""
+    try:
+        sageversion = subprocess.check_output(["sage", "-v"], timeout=10)
+    except OSError:
+        return False
+
+    return "SageMath version" in sageversion.decode("utf-8")
+
+
 def print_decrypted_res(c, logger):
     logger.info(f"HEX : 0x{c.hex()}")
 
@@ -52,88 +64,6 @@ def print_decrypted_res(c, logger):
     logger.info(f"STR : {repr(c)}")
 
 
-def _print_private_key(args, private_keys, logger):
-    logger.info("\nPrivate key :")
-    for priv_key in private_keys:
-        if priv_key is None:
-            continue
-        if args.output:
-            try:
-                with open(args.output, "a") as output_fd:
-                    output_fd.write("%s\n" % str(priv_key))
-            except Exception:
-                logger.error(f"Can't write output file : {args.output}")
-        if not str(priv_key):
-            logger.warning("Key format seems wrong, check input data to solve this.")
-            if priv_key.n is not None:
-                logger.info(f"n: {priv_key.n}")
-            if priv_key.e is not None:
-                logger.info(f"e: {priv_key.e}")
-            if priv_key.d is not None:
-                logger.info(f"d: {priv_key.d}")
-        else:
-            logger.info(priv_key)
-
-
-def _print_dumpkey_private(args, private_keys, logger):
-    logger.info("\nPrivate key details:")
-    for priv_key in private_keys:
-        if priv_key.n is not None:
-            logger.info(f"n: {str(priv_key.n)}")
-        if priv_key.e is not None:
-            logger.info(f"e: {str(priv_key.e)}")
-        if priv_key.d is not None:
-            logger.info(f"d: {str(priv_key.d)}")
-        if priv_key.p is not None:
-            logger.info(f"p: {str(priv_key.p)}")
-        if priv_key.q is not None:
-            logger.info(f"q: {str(priv_key.q)}")
-        if args.ext:
-            dp = priv_key.d % (priv_key.p - 1)
-            dq = priv_key.d % (priv_key.q - 1)
-            pinv = invmod(priv_key.p, priv_key.q)
-            qinv = invmod(priv_key.q, priv_key.p)
-            logger.info(f"dp: {str(dp)}")
-            logger.info(f"dq: {str(dq)}")
-            logger.info(f"pinv: {str(pinv)}")
-            logger.info(f"qinv: {str(qinv)}")
-
-
-def _print_dumpkey_public(args, publickey, logger):
-    for public_key in args.publickey:
-        with open(public_key, "rb") as pubkey_fd:
-            publickey_obj = PublicKey(pubkey_fd.read(), publickey)
-            logger.info("\nPublic key details for %s" % publickey_obj.filename)
-            logger.info(f"n: {str(publickey_obj.n)}")
-            logger.info(f"e: {str(publickey_obj.e)}")
-
-
-def _print_decrypt_results(args, decrypt, logger):
-    if decrypt is None:
-        logger.critical("Sorry, decrypting failed.")
-        return
-    if not isinstance(decrypt, list):
-        decrypt = [decrypt]
-    if len(decrypt) == 0:
-        return
-    logger.info("\nDecrypted data :")
-    for decrypted_ in decrypt:
-        if not isinstance(decrypted_, list):
-            decrypted_ = [decrypted_]
-        for c in decrypted_:
-            if args.output:
-                try:
-                    with open(args.output, "ab") as output_fd:
-                        output_fd.write(c)
-                except Exception:
-                    logger.error(f"Can't write output file : {args.output}")
-            print_decrypted_res(c, logger)
-            if len(c) > 3 and c[0] == 0 and c[1] == 2:
-                nc = c[c[2:].index(0) + 2:]
-                logger.info("\nPKCS#1.5 padding decoded!")
-                print_decrypted_res(nc, logger)
-
-
 def print_results(args, publickey, private_key, decrypt):
     """Print results to output"""
     logger = logging.getLogger("global_logger")
@@ -149,17 +79,90 @@ def print_results(args, publickey, private_key, decrypt):
     if private_key is not None:
         private_keys = private_key if isinstance(private_key, list) else [private_key]
         if args.private:
-            _print_private_key(args, private_keys, logger)
+            logger.info("\nPrivate key :")
+            for priv_key in private_keys:
+                if priv_key is not None:
+                    if args.output:
+                        try:
+                            with open(args.output, "a") as output_fd:
+                                output_fd.write("%s\n" % str(priv_key))
+                        except Exception:
+                            logger.error(f"Can't write output file : {args.output}")
+                    if not str(priv_key):
+                        logger.warning(
+                            "Key format seems wrong, check input data to solve this."
+                        )
+                        if priv_key.n is not None:
+                            logger.info(f"n: {priv_key.n}")
+                        if priv_key.e is not None:
+                            logger.info(f"e: {priv_key.e}")
+                        if priv_key.d is not None:
+                            logger.info(f"d: {priv_key.d}")
+
+                    else:
+                        logger.info(priv_key)
         if args.dumpkey:
-            _print_dumpkey_private(args, private_keys, logger)
+            logger.info("\nPrivate key details:")
+            for priv_key in private_keys:
+                if priv_key.n is not None:
+                    logger.info(f"n: {str(priv_key.n)}")
+                if priv_key.e is not None:
+                    logger.info(f"e: {str(priv_key.e)}")
+                if priv_key.d is not None:
+                    logger.info(f"d: {str(priv_key.d)}")
+                if priv_key.p is not None:
+                    logger.info(f"p: {str(priv_key.p)}")
+                if priv_key.q is not None:
+                    logger.info(f"q: {str(priv_key.q)}")
+                if args.ext:
+                    dp = priv_key.d % (priv_key.p - 1)
+                    dq = priv_key.d % (priv_key.q - 1)
+                    pinv = invmod(priv_key.p, priv_key.q)
+                    qinv = invmod(priv_key.q, priv_key.p)
+                    logger.info(f"dp: {str(dp)}")
+                    logger.info(f"dq: {str(dq)}")
+                    logger.info(f"pinv: {str(pinv)}")
+                    logger.info(f"qinv: {str(qinv)}")
     else:
         if args.private:
             logger.critical("Sorry, cracking failed.")
+
         if args.dumpkey:
-            _print_dumpkey_public(args, publickey, logger)
+            if args.publickey is not None:
+                for public_key in args.publickey:
+                    with open(public_key, "rb") as pubkey_fd:
+                        publickey_obj = PublicKey(pubkey_fd.read(), publickey)
+                        logger.info(
+                            "\nPublic key details for %s" % publickey_obj.filename
+                        )
+                        logger.info(f"n: {str(publickey_obj.n)}")
+                        logger.info(f"e: {str(publickey_obj.e)}")
 
     if args.decrypt:
-        _print_decrypt_results(args, decrypt, logger)
+        if decrypt is not None:
+            if not isinstance(decrypt, list):
+                decrypt = [decrypt]
+            if len(decrypt) > 0:
+                logger.info("\nDecrypted data :")
+                for decrypted_ in decrypt:
+                    if not isinstance(decrypted_, list):
+                        decrypted_ = [decrypted_]
+
+                    for c in decrypted_:
+                        if args.output:
+                            try:
+                                with open(args.output, "ab") as output_fd:
+                                    output_fd.write(c)
+                            except Exception:
+                                logger.error(f"Can't write output file : {args.output}")
+                        print_decrypted_res(c, logger)
+                        if len(c) > 3 and c[0] == 0 and c[1] == 2:
+                            nc = c[c[2:].index(0) + 2 :]
+                            logger.info("\nPKCS#1.5 padding decoded!")
+                            print_decrypted_res(nc, logger)
+
+        else:
+            logger.critical("Sorry, decrypting failed.")
 
 
 class TimeoutError(Exception):
@@ -186,7 +189,7 @@ class timeout(contextlib.ContextDecorator):
         self.suppress = bool(suppress_timeout_errors)
         self.logger = logging.getLogger("global_logger")
 
-    def _timeout_handler(self, _signum, _frame):
+    def _timeout_handler(self, signum, frame):
         self.logger.warning("[!] Timeout.")
         raise TimeoutError(self.timeout_message)
 
@@ -201,7 +204,7 @@ class timeout(contextlib.ContextDecorator):
         )  # this thread will send signal when timeout
         self.timer.start()
 
-    def __exit__(self, exc_type, _exc_val, _exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb):
         self.timer.cancel()
         if self.suppress and exc_type is TimeoutError:
             return True

--- a/src/RsaCtfTool/main.py
+++ b/src/RsaCtfTool/main.py
@@ -410,77 +410,74 @@ def cleanup(args):
                 continue
 
 
-def _setup_logging(args):
-    logging.basicConfig(level=logger_levels[args.verbosity])
+def main():
+    logger = logging.getLogger("global_logger")
+    args = parse_args()
+
+    decrypts = []
+
+    # Set logger level
+    logging.basicConfig(
+        level=logger_levels[args.verbosity],
+    )
     ch = logging.StreamHandler(sys.stderr)
     ch.setFormatter(CustomFormatter())
     logger = logging.getLogger("global_logger")
     logger.propagate = False
     logger.addHandler(ch)
+
+    # Add information
     if not args.private and not args.tests:
         logger.warning(
             "private argument is not set, the private key will not be displayed, even if recovered."
         )
-    return logger
 
-
-def _parse_numeric_args(args):
+    # Parse longs if exists
     if args.p is not None:
         args.p = get_numeric_value(args.p)
+
     if args.q is not None:
         args.q = get_numeric_value(args.q)
+
     if args.d is not None:
         args.d = get_numeric_value(args.d)
+
     if args.n is not None:
         args.n = get_numeric_value(args.n)
+
     if args.e is not None:
-        e_array = [get_numeric_value(e) for e in args.e.split(",")]
+        e_array = []
+        for e in args.e.split(","):
+            e_int = get_numeric_value(e)
+            e_array.append(e_int)
         args.e = e_array if len(e_array) > 1 else e_array[0]
     elif args.n is not None:
         args.e = 65537
-    return args
 
-
-def _warn_if_extra_primes(args, logger):
     if args.n is not None and (args.p is not None or args.q is not None):
         logger.warning(
             "[!] It seems you already provided one of the prime factors, nothing to do here..."
         )
 
-
-def _compute_n_from_pq(args):
+    # get n from p and q
     if args.n is None and args.p is not None and args.q is not None:
         args.n = args.p * args.q
 
+    # get p and q from n, e and d
+    if (
+        args.n is not None
+        and args.e is not None
+        and args.d is not None
+        and args.p is None
+        and args.q is None
+    ):
+        pq = factor_ned(args.n, args.e, args.d)
+        if pq is not None:
+            args.p, args.q = pq
+        else:
+            logger.warning("[!] Impossible to recover p and q from d")
 
-def _recover_pq_from_ned(args, logger):
-    if not (args.n is not None
-            and args.e is not None
-            and args.d is not None
-            and args.p is None
-            and args.q is None):
-        return
-    pq = factor_ned(args.n, args.e, args.d)
-    if pq is not None:
-        args.p, args.q = pq
-    else:
-        logger.warning("[!] Impossible to recover p and q from d")
-
-
-def _compute_other_prime(args):
-    if args.n and (args.p or args.q):
-        args.p, args.q = generate_pq_from_n_and_p_or_q(args.n, args.p, args.q)
-
-
-def _compute_missing_values(args, logger):
-    _warn_if_extra_primes(args, logger)
-    _compute_n_from_pq(args)
-    _recover_pq_from_ned(args, logger)
-    _compute_other_prime(args)
-    return args
-
-
-def _handle_decrypt_input(args, logger):
+    # if we have decrypt but no decryptfile
     if args.decrypt is not None:
         decrypt_array = []
         for decrypt in args.decrypt.split(","):
@@ -490,23 +487,81 @@ def _handle_decrypt_input(args, logger):
                 decrypt = get_base64_value(decrypt)
             decrypt_array.append(n2s(decrypt))
         args.decrypt = decrypt_array
+
+    # if we have decryptfile
     if args.decryptfile is not None:
         if not decrypt_file(args, logger):
             sys.exit(-1)
-    return args
 
+    # If we have n and one of p and q, calculated the other
+    if args.n and (args.p or args.q):
+        args.p, args.q = generate_pq_from_n_and_p_or_q(args.n, args.p, args.q)
 
-def _handle_early_exit_modes(args, logger):
+    # convert a idrsa.pub file to a pem format
     if args.convert_idrsa_pub:
         convert_idrsa_pub(args, logger)
         sys.exit(0)
+
     if args.isroca:
         check_is_roca(args, logger)
         sys.exit(0)
+
+    # Create pubkey if requested
     if args.createpub:
         pub_key, priv_key = generate_keys_from_p_q_e_n(args.p, args.q, args.e, args.n)
         print(pub_key.decode("utf-8"))
         sys.exit(0)
+
+    # Load keys
+    if args.publickey is None and args.e is not None and args.n is not None:
+        args = load_keys(args, logger)
+
+    elif args.publickey is not None:
+        if "*" in args.publickey or "?" in args.publickey:
+            pubkeyfilelist = glob(args.publickey)
+            args.publickey = pubkeyfilelist
+
+        elif "," in args.publickey:
+            args.publickey = args.publickey.split(",")
+        else:
+            args.publickey = [args.publickey]
+
+    # If we already have all information
+    if (
+        args.p is not None
+        and args.q is not None
+        and args.e is not None
+        and args.n is not None
+    ):
+        try:
+            pub_key, priv_key = generate_keys_from_p_q_e_n(
+                args.p, args.q, args.e, args.n
+            )
+        except ValueError:
+            logger.error(
+                "Looks like the values for generating key are not ok... (no invmod)"
+            )
+            sys.exit(1)
+
+        if args.createpub:
+            pub_key, priv_key = generate_keys_from_p_q_e_n(
+                args.p, args.q, args.e, args.n
+            )
+            print(pub_key.decode("utf-8"))
+
+        if args.decrypt is not None:
+            for u in args.decrypt:
+                if priv_key is not None:
+                    decrypts.append(priv_key.decrypt(args.decrypt))
+                else:
+                    logger.error(
+                        "Looks like the values for generating key are not ok... (no invmod)"
+                    )
+                    sys.exit(1)
+        print_results(args, args.publickey[0], priv_key, decrypts)
+        sys.exit(0)
+
+    # Dump public key information
     if (
         args.dumpkey
         and not args.private
@@ -516,79 +571,21 @@ def _handle_early_exit_modes(args, logger):
     ):
         pubkey_detail(args, logger)
         sys.exit(0)
+
+    # if dumpkey mode dump the key components then quit
     if args.key is not None and args.dumpkey:
         dump_key_parameters(args)
         sys.exit(0)
+
     if args.key is not None and args.isconspicuous:
         if run_conspicuous_check(args, logger):
             sys.exit(-1)
-        sys.exit(0)
-    return False
-
-
-def _load_public_keys(args):
-    if args.publickey is None and args.e is not None and args.n is not None:
-        args = load_keys(args, logging.getLogger("global_logger"))
-    elif args.publickey is not None:
-        if "*" in args.publickey or "?" in args.publickey:
-            args.publickey = glob(args.publickey)
-        elif "," in args.publickey:
-            args.publickey = args.publickey.split(",")
         else:
-            args.publickey = [args.publickey]
-    return args
+            sys.exit(0)
 
-
-def _handle_fully_specified_key(args, logger):
-    decrypts = []
-    if not (
-        args.p is not None
-        and args.q is not None
-        and args.e is not None
-        and args.n is not None
-    ):
-        return None
-
-    try:
-        pub_key, priv_key = generate_keys_from_p_q_e_n(args.p, args.q, args.e, args.n)
-    except ValueError:
-        logger.error(
-            "Looks like the values for generating key are not ok... (no invmod)"
-        )
-        sys.exit(1)
-
-    if args.createpub:
-        pub_key, priv_key = generate_keys_from_p_q_e_n(args.p, args.q, args.e, args.n)
-        print(pub_key.decode("utf-8"))
-
-    if args.decrypt is not None:
-        for u in args.decrypt:
-            if priv_key is not None:
-                decrypts.append(priv_key.decrypt(args.decrypt))
-            else:
-                logger.error(
-                    "Looks like the values for generating key are not ok... (no invmod)"
-                )
-                sys.exit(1)
-    print_results(args, args.publickey[0], priv_key, decrypts)
-    sys.exit(0)
-    return decrypts
-
-
-def main():
-    args = parse_args()
-    logger = _setup_logging(args)
-    args = _parse_numeric_args(args)
-    args = _compute_missing_values(args, logger)
-    args = _handle_decrypt_input(args, logger)
-
-    if _handle_early_exit_modes(args, logger):
-        return
-
-    args = _load_public_keys(args)
-    _handle_fully_specified_key(args, logger)
     args = run_attacks(args, logger)
 
+    # Finish and cleanup
     if args.cleanup:
         cleanup(args)
 


### PR DESCRIPTION
This reverts commit a5a060222bf89c35a1510a9d775b716ac0231010.
The commit accidentally removed essential imports such as `os` in `external.py` and `binascii` in `utils.py` while cleaning up unused code via vulture.
As a result, critical functions like `--decrypt` and `--tests` are completely broken and throwing `NameError`. Reverting this commit until a safer refactoring is made would be highly recommended.