### PR TITLE
Some Fixes, Adding Edge cases and Optimizing for Wiener Attack

### DIFF
--- a/src/RsaCtfTool/attacks/multi_keys/hastads.py
+++ b/src/RsaCtfTool/attacks/multi_keys/hastads.py
@@ -18,7 +18,7 @@ class Attack(AbstractAttack):
         if not isinstance(publickeys, list):
             return None, None
 
-        if cipher is None or len(cipher) == 0:
+        if cipher is None or len(cipher) != len(publickeys):
             return None, None
 
         ciphers = [int.from_bytes(c, "big") for c in cipher]

--- a/src/RsaCtfTool/lib/algos.py
+++ b/src/RsaCtfTool/lib/algos.py
@@ -49,9 +49,9 @@ def brent(N):
     if is_prime(N):
         return N
     while True:
-        y = randint(1, N-1)
-        c = randint(1, N-1)
-        m = randint(1, N-1)
+        y = randint(1, N - 1)
+        c = randint(1, N - 1)
+        m = randint(1, N - 1)
 
         g = 1
         r = 1
@@ -68,7 +68,7 @@ def brent(N):
                 ys = y
                 q = 1
 
-                for _ in range(min(m, r-k)):
+                for _ in range(min(m, r - k)):
                     y = (powmod(y, 2, N) + c) % N
                     q = q * abs(x - y) % N
 

--- a/src/RsaCtfTool/lib/algos.py
+++ b/src/RsaCtfTool/lib/algos.py
@@ -42,38 +42,50 @@ sys.setrecursionlimit(100000)
 
 def brent(N):
     """Pollard rho with brent optimizations taken from: https://gist.github.com/ssanin82/18582bf4a1849dfb8afd"""
+    if N < 2:
+        return None
     if N & 1 == 0:
         return 2
     if is_prime(N):
         return N
-    g = N
-    while g == N:
-        y, c, m = randint(1, N - 1), randint(1, N - 1), randint(1, N - 1)
-        g, r, q = 1, 1, 1
+    while True:
+        y = randint(1, N-1)
+        c = randint(1, N-1)
+        m = randint(1, N-1)
+
+        g = 1
+        r = 1
+        q = 1
+        ys = y
+
         while g == 1:
             x = y
-            i = 0
-            while i <= r:
+            for _ in range(r):
                 y = (powmod(y, 2, N) + c) % N
-                i += 1
             k = 0
+
             while k < r and g == 1:
                 ys = y
-                i = 0
-                while i <= min(m, r - k):
+                q = 1
+
+                for _ in range(min(m, r-k)):
                     y = (powmod(y, 2, N) + c) % N
-                    q = q * (abs(x - y)) % N
-                    i += 1
-                g, k = gcd(q, N), k + m
-                if N > g > 1:
-                    return g
+                    q = q * abs(x - y) % N
+
+                g = gcd(q, N)
+                k += m
             r <<= 1
+
         if g == N:
-            while True:
+            g = 1
+
+            while g == 1:
                 ys = (powmod(ys, 2, N) + c) % N
                 g = gcd(abs(x - ys), N)
-                if N > g > 1:
-                    return g
+
+            if g == N:
+                continue
+        return g
 
 
 def strong_pseudoprime(N):
@@ -363,8 +375,14 @@ def quadratic_sieve(n, B=None, M=None, progress=True, n_extra=10, max_retries=6)
     Sieves Q(x) = x^2 - n for B-smooth values, then reuses the same
     GF(2) linear algebra and dependency-checking as Dixon.
     """
+    if n < 2:
+        return None
+
     if n & 1 == 0:
         return 2, n // 2
+
+    if is_prime(n):
+        return None
 
     if B is None:
         ln_n = log(n)

--- a/src/RsaCtfTool/lib/algos.py
+++ b/src/RsaCtfTool/lib/algos.py
@@ -34,6 +34,7 @@ from RsaCtfTool.lib.number_theory import (
     mlucas,
     iroot,
     mulmod,
+    gmpy_version,
 )
 from RsaCtfTool.lib.number_theory import invmod, introot, find_period, is_prime, legendre, tonelli
 
@@ -381,7 +382,7 @@ def quadratic_sieve(n, B=None, M=None, progress=True, n_extra=10, max_retries=6)
     if n & 1 == 0:
         return 2, n // 2
 
-    if is_prime(n):
+    if gmpy_version > 0 and is_prime(n):
         return None
 
     if B is None:

--- a/src/RsaCtfTool/lib/number_theory.py
+++ b/src/RsaCtfTool/lib/number_theory.py
@@ -600,20 +600,33 @@ def rational_to_contfrac(x, y):
 
 def contfrac_to_rational(frac):
     """Contfrac_to_rational implementation"""
-    if len(frac) == 0:
+    if not frac:
         return (0, 1)
-    elif len(frac) == 1:
-        return (frac[0], 1)
-    else:
-        remainder = frac[1:]
-        (num, denom) = contfrac_to_rational(remainder)
-        return (frac[0] * num + denom, num)
+
+    num, denom = frac[-1], 1
+
+    for value in reversed(frac[:-1]):
+        num, denom = value * num + denom, num
+
+    return num, denom
 
 
 def convergents_from_contfrac(frac, progress=False):
     """Convergents_from_contfrac implementation"""
-    return [contfrac_to_rational(frac[:i]) for i in range(0, len(frac))]
+    if not frac:
+        return []
 
+    convergents = [(0, 1)]
+
+    num_prev, num = 0, 1
+    denom_prev, denom = 1, 0
+
+    for value in frac[:-1]:
+        num_prev, num = num, value * num + num_prev
+        denom_prev, denom = denom, value * denom + denom_prev
+        convergents.append((num, denom))
+
+    return convergents
 
 def inv_mod_pow_of_2(factor, bit_count):
     """

--- a/src/RsaCtfTool/lib/number_theory.py
+++ b/src/RsaCtfTool/lib/number_theory.py
@@ -737,4 +737,5 @@ __all__ = [
     is_pow2,
     is_lucas,
     find_period,
+    gmpy_version,
 ]

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -255,7 +255,7 @@ class TestFactorXYXZ:
 class TestWiener:
     """Tests for wiener attack."""
 
-    def test_wiener_small(self): # example from WikiPedia
+    def test_wiener_small(self):  # example from WikiPedia
         p, q = 239, 379
         n = p * q
         e = 17993

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -82,6 +82,48 @@ class TestBrent:
         result = brent(16)
         assert result == 2
 
+    def test_brent_retries_after_g_equals_n(self, monkeypatch):
+        import RsaCtfTool.lib.algos as algos
+
+        n = 15
+        params = iter([
+            1, 1, 1,  # First attempt.
+            2, 1, 1,  # Retry.
+        ])
+
+        monkeypatch.setattr(
+            algos,
+            "randint",
+            lambda _a, _b: next(params),
+        )
+
+        result = algos.brent(n)
+
+        assert result in (3, 5)
+        assert n % result == 0
+
+    def test_brent_uses_fresh_params_after_g_equals_n(self, monkeypatch):
+        import RsaCtfTool.lib.algos as algos
+
+        n = 15
+        params = iter([
+            1, 1, 1,  # First attempt.
+            2, 1, 1,  # Retry.
+        ])
+        calls = []
+
+        def fake_randint(a, b):
+            calls.append((a, b))
+            return next(params)
+
+        monkeypatch.setattr(algos, "randint", fake_randint)
+
+        result = algos.brent(n)
+
+        assert result in (3, 5)
+        assert n % result == 0
+        assert len(calls) == 6
+
 
 class TestPollardRho:
     """Tests for pollard_rho factorization."""

--- a/tests/test_number_theory.py
+++ b/tests/test_number_theory.py
@@ -283,21 +283,37 @@ class TestContfracToRational:
         num, denom = contfrac_to_rational([])
         assert num == 0 and denom == 1
 
+    def test_contfrac_to_rational_multiple_terms(self):
+        assert contfrac_to_rational([3, 7, 16]) == (355, 113)
+
     def test_contfrac_roundtrip(self):
-        original = 22, 7
-        cf = rational_to_contfrac(*original)
-        result = contfrac_to_rational(cf)
-        assert result == original
+        for original in [(22, 7), (13, 11), (355, 113), (12345, 6789)]:
+            cf = rational_to_contfrac(*original)
+            num, denom = contfrac_to_rational(cf)
+            assert num * original[1] == denom * original[0]
 
 
 class TestConvergents:
     """Tests for convergents_from_contfrac function."""
 
     def test_convergents_basic(self):
-        conv = convergents_from_contfrac([3, 7])
-        conv_list = list(conv)
-        assert (3, 1) in conv_list
-        assert (0, 1) in conv_list
+        assert convergents_from_contfrac([3, 7]) == [
+            (0, 1),
+            (3, 1),
+        ]
+
+    def test_convergents_multiple_terms(self):
+        assert convergents_from_contfrac([3, 7, 16]) == [
+            (0, 1),
+            (3, 1),
+            (22, 7),
+        ]
+
+    def test_convergents_empty(self):
+        assert convergents_from_contfrac([]) == []
+
+    def test_convergents_single_term(self):
+        assert convergents_from_contfrac([5]) == [(0, 1)]
 
 
 class TestLegendre:


### PR DESCRIPTION
I found these problems when I ran the test_attacks.py, and attempted fixing some.
## Hastad Attack Fix:
- `test_decrypt_multiple_keys` fails with an `IndexError`, when multiple keys are supplied for fewer ciphertexts, so added a case to cleanly return `(None, None)`.

## Algo fixes in QS and Brent:
- QS was spending lot of time in trying to factor, without first checking if the given inputs are prime, and hence taking long when I ran the tests. (Also checked with `--durations=0` pytest flag) 
- So added check for primality in the beginning.
- Brent Pollard Rho was going into infinite loops when `g == N` (randomly picked in the earlier algo); fixed it by generating fresh params whenever factor recovery fails.

## Wiener attack
- Wiener attack was taking unusually long (~13 sec) and ~14 sec with decrypt. So ran it with python `cProfile` and found the number_theory functions for continued-fractions were the cause.
- They were running on recursion, and hence multiple redundant calculations, so replaced it with iterative calculation.

Please check.

Thank you :)